### PR TITLE
Docs/sessiondocs: sync session quick-card guidance and add PR checklist template quick card sync

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+- Describe what changed and why.
+
+## Validation
+
+- [ ] Local checks run (for example `make dev-check`) or rationale provided.
+- [ ] Risks and rollback notes considered for non-trivial changes.
+
+## Continuity / Docs Checklist
+
+- [ ] `DEV-SESSION.md` updated if this changes ongoing context.
+- [ ] `DECISIONS.md` updated if a planning/architecture decision changed.
+- [ ] If session commands changed, both quick cards were updated in the same commit:
+  - `README.md`
+  - `CONTINUITY-CHECKLIST.md`
+

--- a/CONTINUITY-CHECKLIST.md
+++ b/CONTINUITY-CHECKLIST.md
@@ -2,6 +2,51 @@
 
 Use this runbook whenever you switch machines so work stays synchronized and easy to resume.
 
+## Start Session / Stop Session (Quick Card)
+
+Use this one-screen card for day-to-day continuity.
+
+> Maintenance rule: keep this quick card and the matching section in `README.md` identical. Update both in the same commit.
+
+### Start Session (new work branch)
+
+```bash
+cd ~/Projects/cp-project
+git switch main
+git pull --rebase
+make start-session
+git switch -c feature/<short-name>
+```
+
+### Start Session (continue existing branch)
+
+```bash
+cd ~/Projects/cp-project
+git switch <existing-branch>
+git pull --rebase
+make continuity-status
+```
+
+### Stop Session
+
+Before running the command, update `DEV-SESSION.md` and `DECISIONS.md` (if a planning decision changed).
+
+```bash
+cd ~/Projects/cp-project
+make stop-session MSG="WIP: <short summary>"
+```
+
+### After PR Merge
+
+```bash
+cd ~/Projects/cp-project
+git switch main
+git pull --rebase
+git branch -d <merged-branch>
+```
+
+---
+
 ## Quick Session Commands
 
 Use these when you want a one-command start/stop flow.
@@ -37,7 +82,7 @@ make stop-session MSG="WIP: <short summary>"
 
 ```bash
 cd ~/Projects/cp-project
-git pull
+git pull --rebase
 make continuity-status
 make dev-check
 ```
@@ -47,6 +92,7 @@ make dev-check
 **Where:** PyCharm
 
 - Open `cp-project`
+- Confirm interpreter is `./.venv/bin/python`
 - Use integrated terminal at repo root for `make` commands
 
 ### 3) Pick work branch
@@ -55,16 +101,16 @@ make dev-check
 
 ```bash
 cd ~/Projects/cp-project
-git checkout main
-git pull
-git checkout -b feature/<short-name>
+git switch main
+git pull --rebase
+git switch -c feature/<short-name>
 ```
 
 If branch already exists:
 
 ```bash
 cd ~/Projects/cp-project
-git checkout <existing-branch>
+git switch <existing-branch>
 git pull --rebase
 ```
 
@@ -136,4 +182,4 @@ make dev-check
 make continuity-status
 ```
 
-Then open `cp-project` in PyCharm and set interpreter to `./backend/.venv/bin/python`.
+Then open `cp-project` in PyCharm and set interpreter to `./.venv/bin/python`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,60 @@
 
 This repository is being prepared so you can open it on another machine, bootstrap it quickly, and keep continuity between development environments.
 
+## Start Session / Stop Session (Quick Card)
+
+Pin this section for daily continuity.
+
+> Maintenance rule: keep this quick card and the matching section in `CONTINUITY-CHECKLIST.md` identical. Update both in the same commit.
+
+### Start Session (Terminal)
+
+```bash
+cd ~/Projects/cp-project
+git switch main
+git pull --rebase
+make start-session
+git switch -c feature/<short-name>
+```
+
+If continuing an existing branch:
+
+```bash
+cd ~/Projects/cp-project
+git switch <existing-branch>
+git pull --rebase
+make continuity-status
+```
+
+### Stop Session (PyCharm + Terminal)
+
+1. In PyCharm, update `DEV-SESSION.md` with what changed, next step, and blockers.
+2. If you made a planning choice, update `DECISIONS.md`.
+
+Then in terminal:
+
+```bash
+cd ~/Projects/cp-project
+make stop-session MSG="WIP: <short summary>"
+```
+
+What `make stop-session` does:
+
+- runs homework rollover check (`scripts/homework_rollover.py`)
+- shows `git status`
+- stages changes, commits (if any), and pushes current branch
+
+### After PR Merge (Terminal)
+
+```bash
+cd ~/Projects/cp-project
+git switch main
+git pull --rebase
+git branch -d <merged-branch>
+```
+
+---
+
 ## What this repo contains
 
 - `backend/` — Django + PostgreSQL backend
@@ -160,4 +214,3 @@ make setup
 ```
 
 ---
-


### PR DESCRIPTION
## Summary
- add a repository PR template at `.github/pull_request_template.md`
- add/align one-screen Start/Stop quick cards in:
  - `README.md`
  - `CONTINUITY-CHECKLIST.md`
- normalize continuity commands to `git switch` and `git pull --rebase`

## Why
Keeps session continuity instructions consistent across docs and adds a lightweight PR checklist to prevent drift.

## Validation
- docs-only changes
- command blocks reviewed for copy/paste consistency
