### PR TITLE
docs: soften AGENTS.md status to match MILESTONES.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,12 @@ This file mirrors the shared policy in `docs/reference/ai-guidance.md`.
 cp-project is a full-stack web application for an underground wet utility pipeline contractor to
 manage Extra Work Orders (EWOs) across field capture, costing, review, and billing.
 
-**Current status (2026-04-16):** Milestones 1–2 complete. CI is in place; the EWO schema is
-built out through `WorkDay` children, Job-level OH&P / bond defaults, fuel surcharge, and the
-Caltrans factor-based rate model. An initial navigable UI (Jobs → EWO → WorkDay → line items)
-is live on the dev server. See `DECISIONS_INBOX.md` (DEC-059 onward) for the Phase 1–3 design
-decisions and `DEV-SESSION.md` for the running session log.
+**Current status (2026-04-16):** M2 substantially implemented; Phase 1–3 work has landed in
+development. CI is in place; the EWO schema is built out through `WorkDay` children, Job-level
+OH&P / bond defaults, fuel surcharge, and the Caltrans factor-based rate model. An initial
+navigable UI (Jobs → EWO → WorkDay → line items) is live on the dev server. `MILESTONES.md`
+remains the canonical completion checklist — see `DECISIONS_INBOX.md` (DEC-059 onward) for the
+Phase 1–3 design decisions and `DEV-SESSION.md` for the running session log.
 
 ## Knowledge Pipeline Rules
 


### PR DESCRIPTION
## Summary

Addresses the Copilot review comment on #91 — "Milestones 1–2 complete" contradicted MILESTONES.md, which still carries M1 and M2 as unchecked checklists and is the canonical sign-off record.

Reworded to "M2 substantially implemented; Phase 1–3 work has landed" with an explicit pointer to MILESTONES.md so the roadmap stays authoritative and the two docs agree.

## Test plan

- [ ] Docs-only, no code paths changed. CI should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)